### PR TITLE
Allow unprivileged users to edit their profile

### DIFF
--- a/Services/ApiDataService.php
+++ b/Services/ApiDataService.php
@@ -9,6 +9,7 @@ use Os2Display\CoreBundle\Entity\Screen;
 use Os2Display\CoreBundle\Entity\Slide;
 use Os2Display\CoreBundle\Entity\User;
 use Os2Display\CoreBundle\Security\EditVoter;
+use Os2Display\CoreBundle\Security\Roles;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Security\Core\Role\Role;
 
@@ -92,6 +93,7 @@ class ApiDataService {
           'can_create_channel' => $securityMananger->decide(EditVoter::CREATE, Channel::class),
           'can_create_slide' => $securityMananger->decide(EditVoter::CREATE, Slide::class),
           'can_create_screen' => $securityMananger->decide(EditVoter::CREATE, Screen::class),
+          'can_update_roles' => $securityMananger->decide(Roles::ROLE_USER_ADMIN),
         ];
       }
     }

--- a/Services/UserManager.php
+++ b/Services/UserManager.php
@@ -149,7 +149,7 @@ class UserManager {
    *
    * @throws \Os2Display\CoreBundle\Exception\ValidationException
    */
-  private function authorizeUpdate($user, $data) {
+  private function authorizeUpdate(User $user, $data) {
     // Determine the users current roles and the purposed change.
     $current_roles = $user->getRoles();
     $assigning_roles = isset($data['roles']) ? $data['roles'] : [];
@@ -160,8 +160,8 @@ class UserManager {
 
     // Determine if we're attempting to modify roles, if so, require the current
     // user to be authorized to do so.
-    if ($isChangingRoles && !$this->securityMananager->canAssignRoles($data['roles'])) {
-      throw new ValidationException('No autorized to assign roles', $data['roles']);
+    if ($isChangingRoles && !$this->securityMananager->canAssignRoles($assigning_roles)) {
+      throw new ValidationException('Not autorized to assign roles', $assigning_roles);
     }
   }
 }


### PR DESCRIPTION
This PR attempts to address https://github.com/os2display/admin-bundle/issues/5 by allowing users to perform an update of their own profile as long as they do not attempt to alter roles (unless they have the necessary role).

It also introduces a new "frontend" permission `can_update_roles` which the admin-bundles frontend code then uses to determine whether to present the edit-button for the user or just list the users roles. The updated edit-logic is delivered via https://github.com/os2display/admin-bundle/pull/6

I'm not 100% whether the new role introduced ApiDataService.php is the correct way to go, but it does seem to do the job.