### PR TITLE
Switch to using feed.io (debril.reader has been removed)

### DIFF
--- a/Services/FeedService.php
+++ b/Services/FeedService.php
@@ -51,11 +51,11 @@ class FeedService {
     foreach ($slides as $slide) {
       $options = $slide->getOptions();
 
-      $source = $options['source'];
-
-      if (empty($source)) {
+      if (empty($options['source'])) {
         continue;
       }
+
+      $source = $options['source'];
 
       $md5Source = md5($source);
 
@@ -68,11 +68,11 @@ class FeedService {
       }
       else {
         // Fetch the FeedReader
-        $reader = $this->container->get('debril.reader');
+        $reader = $this->container->get('feedio');
 
         try {
           // Fetch content
-          $feed = $reader->getFeedContent($source);
+          $feed = $reader->read($source)->getFeed();
 
           // Setup return array.
           $res = array(
@@ -83,12 +83,11 @@ class FeedService {
           );
 
           // Get all items.
-          $items = $feed->getItems();
-
-          foreach ($items as $item) {
+          /** @var \FeedIo\Feed\Item $item */
+          foreach ($feed as $item) {
             $res[0]['feed'][] = array(
               'title' => $item->getTitle(),
-              'date' => $item->getUpdated()->format('U'),
+              'date' => $item->getLastModified()->format('U'),
               'description' => $item->getDescription(),
             );
           }


### PR DESCRIPTION
Version 3.0 of rss-atom-bundle and onwards uses `feedio` instead of `debril.reader`, see https://github.com/alexdebril/rss-atom-bundle/blob/master/UPGRADE-3.0.md

This PR makes the switch and also fixes a bit of input-validation.