### PR TITLE
Send absolute URL in user mail

### DIFF
--- a/Services/UserMailerService.php
+++ b/Services/UserMailerService.php
@@ -8,6 +8,7 @@ namespace Os2Display\CoreBundle\Services;
 
 use FOS\UserBundle\Mailer\Mailer;
 use FOS\UserBundle\Model\UserInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * Class UserMailerService
@@ -23,7 +24,7 @@ class UserMailerService extends Mailer {
     $rendered = $this->templating->render(
       'Os2DisplayCoreBundle:User:mailer.html.twig', [
         'name' => $user->getFirstname(),
-        'url' => $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), TRUE),
+        'url' => $this->router->generate('fos_user_resetting_reset', array('token' => $user->getConfirmationToken()), UrlGeneratorInterface::ABSOLUTE_URL),
       ]
     );
 


### PR DESCRIPTION
While testing user creation flow I discovered that the registration URL send in mail wasn't absolute.

In Symfony 3 we can not use boolean as argument and need to use the UrlGeneratorInterface when generating absolute URL.

See also: https://github.com/os2display/admin-bundle/pull/14 which fixes another problem with the user creation flow.

![user-mail-absolute-url](https://user-images.githubusercontent.com/5011234/67948809-ca80cf80-fbe6-11e9-891e-4f59225d25bf.PNG)
