### PR TITLE
docs: update README to reflect current state of 1st gen os2display pr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+> [!Important] 
+> ### This project is no longer actively maintained. 
+> The source code in this repository is no longer maintained. It has been superseded by [version 2](https://os2display.github.io/display-docs/), which offers improved features and better support.
+>
+> Thank you to all who have contributed to this project. We recommend transitioning to [Os2Display version 2](https://os2display.github.io/display-docs/) for continued support and updates.
+>
+> **Final Release**: The final stable release is version [2.2.3](https://github.com/os2display/core-bundle/releases/tag/2.2.3).
+>
+
+
+<br>
+
 # Os2Display core
 
 Installation:


### PR DESCRIPTION
I have added a GitHub compatible "Important" notice in the top of the README